### PR TITLE
Update for env file injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/cyral-quickstart/quickst
 
 The above command will work on just about any system, but you can follow the below directions to create a new instance for the sidecar.
 
-## AWS EC2
+<details>
+    <summary>AWS EC2</summary>
 
 1. Go to [EC2 Service](https://console.aws.amazon.com/ec2)
 1. Select [Launch Instance](https://console.aws.amazon.com/ec2/v2/home#LaunchInstances) and provide the following info
     1. Name: Provide something meaningful like CyralSidecar
-    1. Amazon Machine Image (AMI): The default Amazon Linux image and options are fine, but most images should work
+    1. Amazon Machine Image (AMI): The default Amazon Linux image and options are fine, but most linux based images should work
     1. Instance Type: Our recommended flavor is M5.large, but a T3 or T2 large will work well for a POC as well
     1. Key Pair: Select or create one
     1. Network Settings: Utilize the Edit button on the section header to create a new Security Group for this POC
@@ -32,6 +33,22 @@ The above command will work on just about any system, but you can follow the bel
                 1. Source Type / Source: Provide approrpriate values that will allow your database clients to connect to this port
     1. Launch Instance!
 1. SSH to the new instance and install the sidecar with the above command
+</details>
+
+<details>
+    <summary>Azure VM</summary>
+
+1. Go to [Virtaual Machines](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachines)
+1. Select Create -> [Azure virtual Machine](https://portal.azure.com/#create/Microsoft.VirtualMachine)
+1. Required fields outlined below
+    1. Image: Ubuntu Server 20.04 is the optimal option, however other linux based images should work well too
+    1. Size: A typical POC should work well with a Standard_D2s_v3 (2 cpu/8gb)
+    1. Inbound Ports: you'll want to provide ssh access as well as the approrpiate DB ports you'll want the clients to connect to
+    1. Configure network as needed so both the client has access to the instance, and the instance has access to the DB
+    1. Create Instance!
+1. SSH to the new instance and install the sidecar with the above command
+
+</details>
 
 # Advanced Setup Options
 
@@ -43,6 +60,7 @@ The script will bypass all prompts if the values are provided by environment var
 |controlPlaneUrl|URL of the control plane|
 |sidecarId|Sidecar ID to use|
 |sidecarVersion|Version to use for the sidecar|
+|envFilePath|Environment variable file to use|
 |endpoint|Address to advertise to the CP for configuration|
 |---|---|
 |secretBlob| Json Blob from Sidecar creation|


### PR DESCRIPTION
Few Updates
* Add ability to add env file mount option
* Updated readme for Azure install
* Change Advertised Endpoint logic
* Update dependency install logic to work better on more linux flavors
* Force use sudo for docker commands, because when podman is installed, it will work under the user, but will store to user home folder, which has no space on default azure VM

Tested on
AWS
* Ubuntu 22
* Rhel 8
* AWS Linux

Azure
* Ubuntu 20
*  **RHEL** - doesnt work due to very old package repo from MS