### PR TITLE
Fix fresh install registry auth issue

### DIFF
--- a/install-sidecar.sh
+++ b/install-sidecar.sh
@@ -171,7 +171,7 @@ if [[ -n "$secretBlob" ]]; then
 elif [[ -n "$clientId" && -n "$clientSecret" ]]; then
     echo "clientId and clientSecret enviroment variables found, client ID being used '$clientId'"
 else
-    if [ -n "$inspect" ]; then
+    if [ "[]" != "$inspect" ]; then
         ccid=$(echo "$currentEnv"| grep 'CYRAL_SIDECAR_CLIENT_ID=' | cut -d= -f2)
         ccs=$(echo "$currentEnv"| grep 'CYRAL_SIDECAR_CLIENT_SECRET=' | cut -d= -f2)
 


### PR DESCRIPTION
During a new install, the `docker inspect sidecar` command returns a non-empty string.  Prior conditional statement checked for length of 0 which prevented the Secret Blob prompt to the user.