### PR TITLE
Fix for net-new install

### DIFF
--- a/install-sidecar.sh
+++ b/install-sidecar.sh
@@ -171,7 +171,7 @@ if [[ -n "$secretBlob" ]]; then
 elif [[ -n "$clientId" && -n "$clientSecret" ]]; then
     echo "clientId and clientSecret enviroment variables found, client ID being used '$clientId'"
 else
-    if [ -n "$inspect" ]; then
+    if [ -n "$inspect" -a "$inspect" != "[]" ]; then
         ccid=$(echo "$currentEnv"| grep 'CYRAL_SIDECAR_CLIENT_ID=' | cut -d= -f2)
         ccs=$(echo "$currentEnv"| grep 'CYRAL_SIDECAR_CLIENT_SECRET=' | cut -d= -f2)
 


### PR DESCRIPTION
New installs receive '[]' back from docker inspect command, not NULL.  Add check to not NULL statement to catch this case and prompt user for Secret Blob instead.